### PR TITLE
Add option to hide prefix while chatting

### DIFF
--- a/acs/tabbychat/core/ChatChannel.java
+++ b/acs/tabbychat/core/ChatChannel.java
@@ -34,6 +34,7 @@ public class ChatChannel implements Serializable {
 	protected boolean hasSpam = false;
 	protected int spamCount = 1;
 	public boolean notificationsOn = false;
+	public boolean hidePrefix = false;
 	private String alias;
 	public String cmdPrefix = "";
 	

--- a/acs/tabbychat/core/GuiChatTC.java
+++ b/acs/tabbychat/core/GuiChatTC.java
@@ -449,7 +449,7 @@ public class GuiChatTC extends GuiChat {
 			if(_msg.toString().length() > 0) {
 				List<String> activeTabs = this.tc.getActive();
 				boolean prefixHidden =  this.tc.channelMap.get(activeTabs.get(0)).hidePrefix;
-				String thePrefix = this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix.trim();
+				String thePrefix = this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix;
 				if(!thePrefix.equals("") && prefixHidden && !_msg.substring(0,1).equals("/")) {
 					_msg.insert(0, thePrefix);
 				}

--- a/acs/tabbychat/core/GuiChatTC.java
+++ b/acs/tabbychat/core/GuiChatTC.java
@@ -387,7 +387,8 @@ public class GuiChatTC extends GuiChat {
 				this.inputField2.setText("");
 			} else {
 				String thePrefix = this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix.trim();
-				if(thePrefix.length() > 0) this.inputField2.setText(this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix.trim() + " ");
+				boolean prefixHidden =  this.tc.channelMap.get(activeTabs.get(0)).hidePrefix;
+				if(thePrefix.length() > 0 && !prefixHidden) this.inputField2.setText(this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix.trim() + " ");
 			}
 			ChatBox.enforceScreenBoundary(ChatBox.current);
 		}
@@ -446,6 +447,12 @@ public class GuiChatTC extends GuiChat {
 			StringBuilder _msg = new StringBuilder(1500);
 			for(int i=this.inputList.size()-1; i>=0; i--) _msg.append(this.inputList.get(i).getText());
 			if(_msg.toString().length() > 0) {
+				List<String> activeTabs = this.tc.getActive();
+				boolean prefixHidden =  this.tc.channelMap.get(activeTabs.get(0)).hidePrefix;
+				String thePrefix = this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix.trim();
+				if(!thePrefix.equals("") && prefixHidden && !_msg.substring(0,1).equals("/")) {
+					_msg.insert(0, thePrefix);
+				}
 				TabbyChatUtils.writeLargeChat(_msg.toString());
 				for(int i=1; i<this.inputList.size(); i++) {
 					this.inputList.get(i).setText("");

--- a/acs/tabbychat/core/GuiChatTC.java
+++ b/acs/tabbychat/core/GuiChatTC.java
@@ -449,9 +449,9 @@ public class GuiChatTC extends GuiChat {
 			if(_msg.toString().length() > 0) {
 				List<String> activeTabs = this.tc.getActive();
 				boolean prefixHidden =  this.tc.channelMap.get(activeTabs.get(0)).hidePrefix;
-				String thePrefix = this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix;
+				String thePrefix = this.tc.channelMap.get(activeTabs.get(0)).cmdPrefix.trim();
 				if(!thePrefix.equals("") && prefixHidden && !_msg.substring(0,1).equals("/")) {
-					_msg.insert(0, thePrefix);
+					_msg.insert(0, thePrefix+" ");
 				}
 				TabbyChatUtils.writeLargeChat(_msg.toString());
 				for(int i=1; i<this.inputList.size(); i++) {

--- a/acs/tabbychat/core/TabbyChat.java
+++ b/acs/tabbychat/core/TabbyChat.java
@@ -362,6 +362,7 @@ public class TabbyChat {
 				_new.setAlias(chan.getValue().getAlias());
 				_new.active = chan.getValue().active;
 				_new.notificationsOn = chan.getValue().notificationsOn;
+				_new.hidePrefix = chan.getValue().hidePrefix;
 				_new.cmdPrefix = chan.getValue().cmdPrefix;
 				this.addToChannel(chan.getKey(), new TCChatLine(-1, "-- chat history from "+(new SimpleDateFormat()).format(chanDataFile.lastModified()), 0, true));
 				_new.importOldChat(chan.getValue());

--- a/acs/tabbychat/gui/ChatChannelGUI.java
+++ b/acs/tabbychat/gui/ChatChannelGUI.java
@@ -21,7 +21,7 @@ import net.minecraft.src.GuiScreen;
 public class ChatChannelGUI extends GuiScreen {
 	protected ChatChannel channel;
 	public final int displayWidth = 255;
-	public final int displayHeight = 95;
+	public final int displayHeight = 120;
 	private String title;
 	private int position;
 	private TabbyChat tc;
@@ -33,7 +33,9 @@ public class ChatChannelGUI extends GuiScreen {
 	private static final int CMD_PREFIX_ID = 8985;
 	private static final int PREV_ID = 8986;
 	private static final int NEXT_ID = 8987;
+	private static final int HIDE_PREFIX = 8988;
 	
+	private TCSettingBool hidePrefix = new TCSettingBool(false, "hidePrefix", "settings.channel", HIDE_PREFIX);
 	private TCSettingBool notificationsOn = new TCSettingBool(false, "notificationsOn", "settings.channel", NOTIFICATIONS_ON_ID);
 	private TCSettingTextBox alias = new TCSettingTextBox("", "alias", "settings.channel", ALIAS_ID);
 	private TCSettingTextBox cmdPrefix = new TCSettingTextBox("", "cmdPrefix", "settings.channel", CMD_PREFIX_ID);
@@ -41,6 +43,7 @@ public class ChatChannelGUI extends GuiScreen {
 	public ChatChannelGUI(ChatChannel _c) {
 		this.tc = GuiNewChatTC.getInstance().tc;
 		this.channel = _c;
+		this.hidePrefix.setValue(_c.hidePrefix);
 		this.notificationsOn.setValue(_c.notificationsOn);
 		this.alias.setCharLimit(20);
 		this.alias.setValue(_c.getAlias());
@@ -56,6 +59,7 @@ public class ChatChannelGUI extends GuiScreen {
 			this.channel.notificationsOn = this.notificationsOn.getTempValue();
 			this.channel.setAlias(this.alias.getTempValue().trim());
 			this.channel.cmdPrefix = this.cmdPrefix.getTempValue().trim();
+			this.channel.hidePrefix = this.hidePrefix.getTempValue();
 			this.tc.storeChannelData();
 		case CANCEL_ID:
 			mc.displayGuiScreen((GuiScreen)null);
@@ -77,6 +81,8 @@ public class ChatChannelGUI extends GuiScreen {
 			this.tc.channelMap = newMap2;
 			this.position++;
 			break;
+		case HIDE_PREFIX:
+			this.hidePrefix.actionPerformed();
 		}
 	}
 	
@@ -137,6 +143,11 @@ public class ChatChannelGUI extends GuiScreen {
 		this.cmdPrefix.setButtonDims(100, 11);
 		this.buttonList.add(this.cmdPrefix);
 		
+		this.hidePrefix.setButtonLoc(leftX+15, topY+78);
+		this.hidePrefix.setLabelLoc(leftX+34);
+		this.buttonList.add(this.hidePrefix);
+		
+		
 		// Determine tab position
 		position = 1;
 		int numTabs = this.tc.channelMap.size();
@@ -178,6 +189,7 @@ public class ChatChannelGUI extends GuiScreen {
 	}
 	
 	public void resetTempVars() {
+		this.hidePrefix.reset();
 		this.notificationsOn.reset();
 		this.alias.reset();
 		this.cmdPrefix.reset();

--- a/acs/tabbychat/lang/TCLanguageEnglish.java
+++ b/acs/tabbychat/lang/TCLanguageEnglish.java
@@ -123,6 +123,7 @@ public class TCLanguageEnglish extends TCLanguage {
 		defaults.setProperty("settings.channel.cmdprefix", "Chat command prefix");
 		defaults.setProperty("settings.channel.position", "Position:");
 		defaults.setProperty("settings.channel.of", "of");
+		defaults.setProperty("settings.channel.hideprefix", "Hide prefix while typing");
 		
 		// ENGLISH STRINGS FOR MESSAGES
 		defaults.setProperty("messages.update1", "An update is available! (Current version is ");


### PR DESCRIPTION
This pull adds an option to the GuiChatTC screen (the GUI when editing a tab). The option is labeled "Hide prefix while typing". With this option enabled, the prefix specified for the channel will not be shown in the chat box while typing into the channel, but it will be prepended to what text was entered when the message is sent to the server. Also, if what was typed in starts with a slash, the prefix is NOT prepended (so the user's command is executed normally).
